### PR TITLE
Ajout du modèle vectoriel

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -10,16 +10,36 @@ PostingList = List[DocID]
 
 
 class Index:
-    """Represents an index."""
+    """Represents an index.
+
+    Parameters
+    ----------
+    postings : dict
+        Mapping of terms to a list of doc IDs.
+    terms : set
+        Set of unique tokens.
+    doc_ids : set
+        Set of unique doc IDs.
+    df : dict
+        Document frequency for each term, i.e. number of documents that
+        contain the term.
+    """
 
     def __init__(
         self,
         postings: Dict[Term, PostingList],
         terms: Set[Term],
         doc_ids: Set[DocID],
+        df: Dict[Term, int],
     ):
         self.postings: DefaultDict[Term, PostingList] = defaultdict(
             int, **postings
         )
         self.terms = terms
         self.doc_ids = doc_ids
+        self.df = df
+
+    @property
+    def num_documents(self) -> int:
+        """Number of documents in the collection."""
+        return len(self.doc_ids)

--- a/models/vector.py
+++ b/models/vector.py
@@ -1,0 +1,138 @@
+"""Vector search model implementation."""
+from collections import defaultdict
+from heapq import nlargest
+from math import sqrt, log10
+from typing import List, Dict, Type, Union
+
+from datatypes import Index, DocID, Term, PostingList
+from tokenizers import Tokenizer
+
+
+class WeightingScheme:
+    """Base weighting scheme class."""
+
+    weights: List[Dict[DocID, float]]
+
+    def __init__(self, index: Index, terms: List[str]):
+        self.index = index
+        self.terms = terms
+        self.weights = [defaultdict(float) for _ in terms]
+
+    def norm(self, doc_id: DocID) -> float:
+        """Return a document's normalization factor.
+
+        Parameters
+        ----------
+        doc_id : int
+
+        Returns
+        -------
+        norm : float
+        """
+        raise NotImplementedError
+
+    def tf(self, term: Term, doc: Union[DocID, str]) -> float:
+        """Return the frequency of a term in a document.
+
+        Parameters
+        ----------
+        term : str
+        doc : str or int
+            Either a string (for non-indexed documents) or a document ID
+            (for indexed documents).
+
+        Returns
+        -------
+        tf : float
+        """
+        raise NotImplementedError
+
+    def df(self, term: Term) -> float:
+        """Return the document frequency of a term.
+
+        Parameters
+        ----------
+        term : str
+
+        Returns
+        -------
+        df : float
+        """
+        raise NotImplementedError
+
+    def __call__(self, term: Term, doc_id: DocID) -> float:
+        """Compute the weight of a term relative to a document.
+
+        Parameters
+        ----------
+        term : str
+        doc_id : int
+
+        Returns
+        -------
+        weight : float
+        """
+        return self.norm(doc_id) * self.df(term) * self.tf(term, doc_id)
+
+
+class TfIdf(WeightingScheme):
+    """TF-IDF weighting scheme."""
+
+    def norm(self, doc_id: DocID) -> float:
+        d2 = sum(weights[doc_id] for weights in self.weights)
+        return 1 / sqrt(d2)
+
+    def tf(self, term: Term, doc: Union[DocID, str]) -> float:
+        if isinstance(doc, str):
+            # Reuse the tokenize algorithm.
+            tokens = Tokenizer().tokenize(doc)
+            return sum(1 for token in tokens if token == term)
+        else:
+            doc_ids: PostingList = self.index.postings[term]
+            return sum(1 for doc_id in doc_ids if doc_id == doc)
+
+    def df(self, term: Term) -> float:
+        return log10(self.index.num_documents / self.index.df[term])
+
+
+def vector_search(
+    request: str, index: Index, k: int = 10, wcs: Type[WeightingScheme] = None,
+) -> List[DocID]:
+    """Perform a vector-space search.
+
+    Parameters
+    ----------
+    request : str
+        A request as a string of words.
+    index : Index
+        A search index.
+    k : int, optional
+        Maximum number of documents to return. Defaults to 10.
+    wcs : class, optional
+        A weighting scheme class. Defaults to `TfIdf`.
+    """
+    if wcs is None:
+        wcs = TfIdf
+
+    scores: Dict[DocID, float] = {doc_id: 0 for doc_id in index.doc_ids}
+    # Weights of request terms
+    wq: List[float] = {}
+    w = wcs(index=index, terms=request.split())
+
+    for i, term in enumerate(w.terms):
+        wq_i = w.tf(term, request) * w.df(term)
+        wq.append(wq_i)
+
+        for doc_id in index.postings[term]:
+            w_i_dj = w(term, doc_id)
+            w.weights[i][doc_id] = w_i_dj
+            scores[doc_id] += w_i_dj * wq_i
+
+    norm_q = sum(wq_i ** 2 for wq_i in wq)
+
+    for doc_id in index.doc_ids:
+        if scores[doc_id]:
+            scores[doc_id] /= (sqrt(w.norm(doc_id)) * sqrt(norm_q))
+
+    top_k: list = nlargest(k, scores.items(), key=lambda item: item[1])
+    return [doc_id for doc_id, _ in top_k]

--- a/tokenizers.py
+++ b/tokenizers.py
@@ -22,13 +22,10 @@ class Tokenizer:
     def __init__(self):
         self.stop_words = load_stop_words()
 
-    def tokenize(self, text: str, stop_words: Set[str] = None) -> TokenStream:
+    def tokenize(self, text: str) -> TokenStream:
         """Separate a text into a set of tokens."""
-        if stop_words is None:
-            stop_words = self.stop_words
         tokens = filter(None, self.NON_ALPHA_NUMERIC.split(text))
         tokens = map(str.lower, tokens)
-        tokens = filter(lambda t: t not in stop_words, tokens)
         return tokens
 
     def __iter__(self) -> TokenDocIDStream:
@@ -47,6 +44,14 @@ class CACM(Tokenizer):
     def __init__(self):
         super().__init__()
         self.filename = os.getenv(self.location_env_var)
+        self.stop_words = load_stop_words()
+
+    def tokenize(self, text: str, stop_words: Set[str] = None):
+        if stop_words is None:
+            stop_words = self.stop_words
+        tokens = super().tokenize(text)
+        tokens = filter(lambda t: t not in stop_words, tokens)
+        return tokens
 
     def _from_file(self) -> TokenDocIDStream:
         """Load tokens and doc_ids from the CACM collection from disk."""


### PR DESCRIPTION
# Changements

Préparatoire :

- Ajout de la *document frequency* pour chaque terme dans l'index (utilisé par le modèle vectoriel).
- Refactoring des tokenizers : les stop words ne sont plus utilisés que sur CACM, comme ça aurait toujours dû être le cas.

Le reste est l'implémentation du modèle vectoriel selon la slide 178 du cours 1 "Indexation". J'ai créé une classe de base pour qu'on puisse tester plusieurs schémas de pondération comme demandé dans le sujet, avec TF-IDF pour le schéma de base. Par contre si on veut tester d'autres mesures de similarité (c'est optionnel dans le sujet) que la mesure cosinus, il faudra refactorer.