### PR TITLE
Vector search improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ python -m models.boolean <COLLECTION>
 python -m models.boolean CACM
 ```
 
+### Vector requests
+
+To make a request against a collection using the vector model, use:
+
+```python
+python -m models.boolean <COLLECTION> <QUERY>
+# Example:
+python -m models.boolean CACM "search algorithm"
+```
+
+Complete usage:
+
+```bash
+$ python -m models.vector --help
+Usage: __main__.py [OPTIONS] COLLECTION QUERY
+
+  Search a collection using the vector model.
+
+Options:
+  -k, --topk INTEGER          [default: 10]
+  -w, --weighting-scheme WCS  [default: simple]
+  --help                      Show this message and exit.
+```
+
 ## Credits
 
 Made by Alexandre de Boutray & Florimond Manca.

--- a/cli_utils.py
+++ b/cli_utils.py
@@ -17,3 +17,20 @@ class CollectionType(click.ParamType):
             )
         else:
             return cls()
+
+
+class WeightingSchemeClassType(click.ParamType):
+
+    name = "wcs"
+
+    def __init__(self, schemes):
+        super().__init__()
+        self.schemes = schemes
+
+    def convert(self, value, param, ctx):
+        try:
+            scheme = self.schemes[value]
+        except KeyError:
+            raise click.BadParameter(f"Unknown weighting scheme: {value}")
+        else:
+            return scheme

--- a/cli_utils.py
+++ b/cli_utils.py
@@ -17,20 +17,3 @@ class CollectionType(click.ParamType):
             )
         else:
             return cls()
-
-
-class WeightingSchemeClassType(click.ParamType):
-
-    name = "wcs"
-
-    def __init__(self, schemes):
-        super().__init__()
-        self.schemes = schemes
-
-    def convert(self, value, param, ctx):
-        try:
-            scheme = self.schemes[value]
-        except KeyError:
-            raise click.BadParameter(f"Unknown weighting scheme: {value}")
-        else:
-            return scheme

--- a/models/vector.py
+++ b/models/vector.py
@@ -4,20 +4,25 @@ from heapq import nlargest
 from math import sqrt, log10
 from typing import List, Dict, Type, Union
 
+import click
+
+from cli_utils import CollectionType, WeightingSchemeClassType
 from datatypes import DocID, Term, PostingList
-from indexes import Index
+from indexes import Index, build_index
 from data_collections import Collection
 
 
 class WeightingScheme:
     """Base weighting scheme class."""
 
-    weights: List[Dict[DocID, float]]
+    name: str
 
-    def __init__(self, index: Index, terms: List[str]):
+    def __init__(self, index: Index, query: List[str]):
         self.index = index
-        self.terms = terms
-        self.weights = [defaultdict(float) for _ in terms]
+        self.query = query
+        self.weights: List[Dict[DocID, float]] = [
+            defaultdict(float) for _ in query
+        ]
 
     def norm(self, doc_id: DocID) -> float:
         """Return a document's normalization factor.
@@ -76,24 +81,49 @@ class WeightingScheme:
         return self.norm(doc_id) * self.df(term) * self.tf(term, doc_id)
 
 
-class TfIdf(WeightingScheme):
-    """TF-IDF weighting scheme."""
+class TfIdfSimple(WeightingScheme):
+    """A simple tf-idf weighting scheme."""
+
+    name = "simple"
 
     def norm(self, doc_id: DocID) -> float:
-        d2 = sum(weights[doc_id] for weights in self.weights)
-        return 1 / sqrt(d2)
+        return 1
 
     def tf(self, term: Term, doc: Union[DocID, str]) -> float:
         if isinstance(doc, str):
             # Reuse the tokenize algorithm.
             tokens = Collection().tokenize(doc)
             return sum(1 for token in tokens if token == term)
-        else:
-            doc_ids: PostingList = self.index.postings[term]
-            return sum(1 for doc_id in doc_ids if doc_id == doc)
+
+        doc_ids: PostingList = self.index.postings[term]
+        return sum(1 for doc_id in doc_ids if doc_id == doc)
 
     def df(self, term: Term) -> float:
-        return log10(self.index.num_documents / self.index.df[term])
+        return 1
+
+
+class TfIdfComplex(TfIdfSimple):
+    """A more complex tf-idf weighting scheme."""
+
+    name = "complex"
+
+    def norm(self, doc_id: DocID) -> float:
+        d2 = sum(weights[doc_id] for weights in self.weights)
+        return 1 / sqrt(d2) if d2 else 1
+
+    def tf(self, term: Term, doc: Union[DocID, str]) -> float:
+        tf = super().tf(term, doc)
+        return 1 + log10(tf) if tf > 0 else 0
+
+    def df(self, term: Term) -> float:
+        df_t = self.index.df[term]
+        return 1 / df_t if df_t else 0
+
+
+SCHEMES: Dict[str, Type[WeightingScheme]] = {}
+
+for _wcs in (TfIdfSimple, TfIdfComplex):
+    SCHEMES[_wcs.name] = _wcs
 
 
 def vector_search(
@@ -113,27 +143,54 @@ def vector_search(
         A weighting scheme class. Defaults to `TfIdf`.
     """
     if wcs is None:
-        wcs = TfIdf
+        wcs = TfIdfSimple
 
     scores: Dict[DocID, float] = {doc_id: 0 for doc_id in index.doc_ids}
     # Weights of request terms
-    wq: List[float] = {}
-    w = wcs(index=index, terms=request.split())
+    wq: List[float] = []
+    w = wcs(index=index, query=list(Collection().tokenize(request)))
 
-    for i, term in enumerate(w.terms):
-        wq_i = w.tf(term, request) * w.df(term)
-        wq.append(wq_i)
+    for term_id, term in enumerate(w.query):
+        w_i_q = w.weights[term_id][request] = w.tf(term, request) * w.df(term)
+        wq.append(w_i_q)
 
         for doc_id in index.postings[term]:
             w_i_dj = w(term, doc_id)
-            w.weights[i][doc_id] = w_i_dj
-            scores[doc_id] += w_i_dj * wq_i
+            w.weights[term_id][doc_id] = w_i_dj
+            scores[doc_id] += w_i_dj * w_i_q
 
-    norm_q = sum(wq_i ** 2 for wq_i in wq)
+    norm_q = sum(w_i_q ** 2 for w_i_q in wq)
 
     for doc_id in index.doc_ids:
         if scores[doc_id]:
-            scores[doc_id] /= sqrt(w.norm(doc_id)) * sqrt(norm_q)
+            scores[doc_id] /= sqrt(w.norm(doc_id)) * sqrt(norm_q) or 1
 
     top_k: list = nlargest(k, scores.items(), key=lambda item: item[1])
     return [doc_id for doc_id, _ in top_k]
+
+
+@click.command()
+@click.argument("collection", type=CollectionType())
+@click.argument("query")
+@click.option("--topk", "-k", type=int, default=10)
+@click.option(
+    "--weighting-scheme", "-w", "wcs", type=WeightingSchemeClassType(SCHEMES)
+)
+def cli(
+    collection: Collection, query: str, topk: int, wcs: Type[WeightingScheme]
+):
+    """Test the boolean model on a collection."""
+    index = build_index(collection)
+
+    click.echo(f"Weighting scheme: {wcs.name}")
+
+    click.echo("Query: ", nl=False)
+    click.echo(click.style(query, fg="blue"))
+
+    results = vector_search(query, index, k=topk, wcs=wcs)
+
+    click.echo(click.style(f"Results: {results}", fg="green"))
+
+
+if __name__ == "__main__":
+    cli()

--- a/models/vector/__main__.py
+++ b/models/vector/__main__.py
@@ -1,0 +1,38 @@
+from typing import Type
+
+import click
+
+from cli_utils import CollectionType
+from data_collections import Collection
+from indexes import build_index
+
+from .cli_utils import WeightingSchemeClassType
+from .schemes import SCHEMES, WeightingScheme
+from .search import vector_search
+
+
+@click.command()
+@click.argument("collection", type=CollectionType())
+@click.argument("query")
+@click.option("--topk", "-k", type=int, default=10)
+@click.option(
+    "--weighting-scheme", "-w", "wcs", type=WeightingSchemeClassType(SCHEMES)
+)
+def cli(
+    collection: Collection, query: str, topk: int, wcs: Type[WeightingScheme]
+):
+    """Test the boolean model on a collection."""
+    index = build_index(collection)
+
+    click.echo(f"Weighting scheme: {wcs.name}")
+
+    click.echo("Query: ", nl=False)
+    click.echo(click.style(query, fg="blue"))
+
+    results = vector_search(query, index, k=topk, wcs=wcs)
+
+    click.echo(click.style(f"Results: {results}", fg="green"))
+
+
+if __name__ == "__main__":
+    cli()

--- a/models/vector/__main__.py
+++ b/models/vector/__main__.py
@@ -7,7 +7,7 @@ from data_collections import Collection
 from indexes import build_index
 
 from .cli_utils import WeightingSchemeClassType
-from .schemes import SCHEMES, WeightingScheme
+from .schemes import SCHEMES, WeightingScheme, TfIdfSimple
 from .search import vector_search
 
 
@@ -16,7 +16,11 @@ from .search import vector_search
 @click.argument("query")
 @click.option("--topk", "-k", type=int, default=10)
 @click.option(
-    "--weighting-scheme", "-w", "wcs", type=WeightingSchemeClassType(SCHEMES)
+    "--weighting-scheme",
+    "-w",
+    "wcs",
+    type=WeightingSchemeClassType(SCHEMES),
+    default=TfIdfSimple.name,
 )
 def cli(
     collection: Collection, query: str, topk: int, wcs: Type[WeightingScheme]

--- a/models/vector/__main__.py
+++ b/models/vector/__main__.py
@@ -14,13 +14,14 @@ from .search import vector_search
 @click.command()
 @click.argument("collection", type=CollectionType())
 @click.argument("query")
-@click.option("--topk", "-k", type=int, default=10)
+@click.option("--topk", "-k", type=int, default=10, show_default=True)
 @click.option(
     "--weighting-scheme",
     "-w",
     "wcs",
     type=WeightingSchemeClassType(SCHEMES),
     default=TfIdfSimple.name,
+    show_default=True,
 )
 def cli(
     collection: Collection, query: str, topk: int, wcs: Type[WeightingScheme]

--- a/models/vector/__main__.py
+++ b/models/vector/__main__.py
@@ -25,7 +25,7 @@ from .search import vector_search
 def cli(
     collection: Collection, query: str, topk: int, wcs: Type[WeightingScheme]
 ):
-    """Test the boolean model on a collection."""
+    """Search a collection using the vector model."""
     index = build_index(collection)
 
     click.echo(f"Weighting scheme: {wcs.name}")

--- a/models/vector/cli_utils.py
+++ b/models/vector/cli_utils.py
@@ -1,0 +1,22 @@
+from typing import Dict, Type
+
+import click
+
+from .schemes import WeightingScheme
+
+
+class WeightingSchemeClassType(click.ParamType):
+
+    name = "wcs"
+
+    def __init__(self, schemes: Dict[str, Type[WeightingScheme]]):
+        super().__init__()
+        self.schemes = schemes
+
+    def convert(self, value, param, ctx) -> Type[WeightingScheme]:
+        try:
+            scheme = self.schemes[value]
+        except KeyError:
+            raise click.BadParameter(f"Unknown weighting scheme: {value}")
+        else:
+            return scheme

--- a/models/vector/schemes.py
+++ b/models/vector/schemes.py
@@ -1,15 +1,12 @@
-"""Vector search model implementation."""
+"""Vector search weighting schemes."""
+
 from collections import defaultdict
-from heapq import nlargest
+from typing import Dict, List, Union, Type
 from math import sqrt, log10
-from typing import List, Dict, Type, Union
 
-import click
-
-from cli_utils import CollectionType, WeightingSchemeClassType
-from datatypes import DocID, Term, PostingList
-from indexes import Index, build_index
 from data_collections import Collection
+from datatypes import DocID, PostingList, Term
+from indexes import Index
 
 
 class WeightingScheme:
@@ -124,73 +121,3 @@ SCHEMES: Dict[str, Type[WeightingScheme]] = {}
 
 for _wcs in (TfIdfSimple, TfIdfComplex):
     SCHEMES[_wcs.name] = _wcs
-
-
-def vector_search(
-    request: str, index: Index, k: int = 10, wcs: Type[WeightingScheme] = None
-) -> List[DocID]:
-    """Perform a vector-space search.
-
-    Parameters
-    ----------
-    request : str
-        A request as a string of words.
-    index : Index
-        A search index.
-    k : int, optional
-        Maximum number of documents to return. Defaults to 10.
-    wcs : class, optional
-        A weighting scheme class. Defaults to `TfIdf`.
-    """
-    if wcs is None:
-        wcs = TfIdfSimple
-
-    scores: Dict[DocID, float] = {doc_id: 0 for doc_id in index.doc_ids}
-    # Weights of request terms
-    wq: List[float] = []
-    w = wcs(index=index, query=list(Collection().tokenize(request)))
-
-    for term_id, term in enumerate(w.query):
-        w_i_q = w.weights[term_id][request] = w.tf(term, request) * w.df(term)
-        wq.append(w_i_q)
-
-        for doc_id in index.postings[term]:
-            w_i_dj = w(term, doc_id)
-            w.weights[term_id][doc_id] = w_i_dj
-            scores[doc_id] += w_i_dj * w_i_q
-
-    norm_q = sum(w_i_q ** 2 for w_i_q in wq)
-
-    for doc_id in index.doc_ids:
-        if scores[doc_id]:
-            scores[doc_id] /= sqrt(w.norm(doc_id)) * sqrt(norm_q) or 1
-
-    top_k: list = nlargest(k, scores.items(), key=lambda item: item[1])
-    return [doc_id for doc_id, _ in top_k]
-
-
-@click.command()
-@click.argument("collection", type=CollectionType())
-@click.argument("query")
-@click.option("--topk", "-k", type=int, default=10)
-@click.option(
-    "--weighting-scheme", "-w", "wcs", type=WeightingSchemeClassType(SCHEMES)
-)
-def cli(
-    collection: Collection, query: str, topk: int, wcs: Type[WeightingScheme]
-):
-    """Test the boolean model on a collection."""
-    index = build_index(collection)
-
-    click.echo(f"Weighting scheme: {wcs.name}")
-
-    click.echo("Query: ", nl=False)
-    click.echo(click.style(query, fg="blue"))
-
-    results = vector_search(query, index, k=topk, wcs=wcs)
-
-    click.echo(click.style(f"Results: {results}", fg="green"))
-
-
-if __name__ == "__main__":
-    cli()

--- a/models/vector/search.py
+++ b/models/vector/search.py
@@ -1,0 +1,53 @@
+"""Vector search algorithm implementation."""
+from heapq import nlargest
+from typing import Dict, List, Type
+from math import sqrt
+
+from data_collections import Collection
+from datatypes import DocID
+from indexes import Index
+
+from .schemes import WeightingScheme, TfIdfSimple
+
+
+def vector_search(
+    request: str, index: Index, k: int = 10, wcs: Type[WeightingScheme] = None
+) -> List[DocID]:
+    """Perform a vector-space search.
+
+    Parameters
+    ----------
+    request : str
+        A request as a string of words.
+    index : Index
+        A search index.
+    k : int, optional
+        Maximum number of documents to return. Defaults to 10.
+    wcs : class, optional
+        A weighting scheme class. Defaults to `TfIdfSimple`.
+    """
+    if wcs is None:
+        wcs = TfIdfSimple
+
+    scores: Dict[DocID, float] = {doc_id: 0 for doc_id in index.doc_ids}
+    # Weights of request terms
+    wq: List[float] = []
+    w = wcs(index=index, query=list(Collection().tokenize(request)))
+
+    for term_id, term in enumerate(w.query):
+        w_i_q = w.weights[term_id][request] = w.tf(term, request) * w.df(term)
+        wq.append(w_i_q)
+
+        for doc_id in index.postings[term]:
+            w_i_dj = w(term, doc_id)
+            w.weights[term_id][doc_id] = w_i_dj
+            scores[doc_id] += w_i_dj * w_i_q
+
+    norm_q = sum(w_i_q ** 2 for w_i_q in wq)
+
+    for doc_id in index.doc_ids:
+        if scores[doc_id]:
+            scores[doc_id] /= sqrt(w.norm(doc_id)) * sqrt(norm_q) or 1
+
+    top_k: list = nlargest(k, scores.items(), key=lambda item: item[1])
+    return [doc_id for doc_id, _ in top_k]


### PR DESCRIPTION
Le requêtage fonctionne sur CACM, mais quand l'un des mots de la requête n'est pas présent dans l'index, le résultat est bidon, du type `[1, 2, 3, …]` vu que tous les poids sont à 0. Je ne sais pas si c'est voulu, on pourra voir au moment où on fera l'évaluation (comparaison avec des résultats attendus).

Avant on n'avait qu'un seul schéma de pondération (un tf-idf modifié), on en a maintenant 2 :

- tf-idf "simple" correspondant à la première ligne du tableau des schémas de pondération (slide 107 du cours)
- tf-idf "complexe" correspondant à la 3e ligne.

Comme ça on tick le requirement d'avoir comparé plusieurs schémas de pondération.
